### PR TITLE
Added support for Postgresql

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,9 +12,12 @@ EXPOSE 8000
 
 ARG DEV=false
 RUN pip install --upgrade pip && \
+    apk add --update --no-cache postgresql-client && \
+    apk add --update --no-cache --virtual .tmp-build-deps build-base postgresql-dev musl-dev && \
     pip install -r /tmp/requirements.txt && \
     if [ "$DEV" = "true" ]; then pip install -r /tmp/requirements.dev.txt; fi && \
     rm -rf /tmp && \
+    apk del .tmp-build-deps && \
     adduser --disabled-password --no-create-home codesirius
 
 USER codesirius

--- a/backend/codesirius/codesirius/settings.py
+++ b/backend/codesirius/codesirius/settings.py
@@ -83,8 +83,11 @@ WSGI_APPLICATION = "codesirius.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "ENGINE": "django.db.backends.postgresql",
+        "HOST": environ.get("DB_HOST"),
+        "NAME": environ.get("DB_NAME"),
+        "USER": environ.get("DB_USER"),
+        "PASSWORD": environ.get("DB_PASSWORD"),
     }
 }
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,3 +34,4 @@ tomli==2.2.1
 tomlkit==0.13.2
 typing_extensions==4.12.2
 virtualenv==20.28.1
+psycopg2==2.9.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,58 @@
 services:
   backend:
     build:
-        context: backend
-        dockerfile: Dockerfile
-        args:
-          - DEV=true
+      context: backend
+      dockerfile: Dockerfile
+      args:
+        - DEV=true
     ports:
       - "8000:8000"
     volumes:
-        - ./backend/codesirius:/app/codesirius
+      - ./backend/codesirius:/app/codesirius
     working_dir: /app/codesirius
     command: >
-        sh -c "python manage.py runserver 0.0.0.0:8000"
+      sh -c "python manage.py runserver 0.0.0.0:8000"
+    environment:
+      - DB_HOST=db
+      - DB_NAME=codesirius
+      - DB_USER=codesirius
+      - DB_PASSWORD=codesirius
+    depends_on:
+      db:
+        condition: service_healthy
+  db:
+    image: postgres:14.15-alpine3.21
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    environment:
+      # credentials are hardcoded as it is only for development
+      POSTGRES_USER: codesirius
+      POSTGRES_PASSWORD: codesirius
+      POSTGRES_DB: codesirius
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U codesirius" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+
 
   frontend:
     build:
-        context: frontend
-        dockerfile: Dockerfile
-        args:
-          - DEV=true
+      context: frontend
+      dockerfile: Dockerfile
+      args:
+        - DEV=true
     ports:
       - "3000:3000"
     volumes:
-        - ./frontend:/app
+      - ./frontend:/app
     working_dir: /app
     command: >
-        sh -c "npm run dev"
+      sh -c  "npm run dev"
+
+volumes:
+  postgres_data:
+      


### PR DESCRIPTION
This fixes #31

**Checklist:**

- [x] added Postgresql 14.15 as a service defined in `docker-compose.yml`
- [x] service `backend` now depends on service `db`
- [x] added health check condition on the service `db`
- [x] service `backend` only starts if the health check conditions passes on the service `db`
- [x] added psycopg2 package at `requirements.txt` 
- [x] configured django to connect with the `postgresql` server


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Migrated database backend from SQLite to PostgreSQL
	- Added PostgreSQL database service to Docker Compose configuration

- **Chores**
	- Updated Docker image build process to support PostgreSQL client
	- Added PostgreSQL Python adapter (psycopg2) as a project dependency
	- Configured environment-based database connection settings

- **Infrastructure**
	- Introduced persistent PostgreSQL data volume
	- Added health checks for database service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->