### PR TITLE
Deploy to EC2 via Tailscale and various fixes/improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy to EC2 via Tailscale
+on:
+    push:
+        branches:
+        - main
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Connect Tailscale
+            uses: tailscale/github-action@v2
+            with:
+              oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+              oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+              tags: tag:ci
+
+          - name: Deploy to AWS
+            run: |
+              ssh -o StrictHostKeyChecking=no codesirius "
+              cd /home/parthokr/segfault
+              git pull
+              docker compose up -d
+              "

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Deploy to AWS
         run: |
           ssh -o StrictHostKeyChecking=no codesirius "
-          cd /home/parthokr/segfault
+          cd ${{ secrets.PROJECT_PATH }}
           git pull
           docker compose up -d
           "

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,23 +1,23 @@
 name: Deploy to EC2 via Tailscale
 on:
-    push:
-        branches:
-        - main
+  push:
+    branches:
+      - main
 jobs:
-    deploy:
-        runs-on: ubuntu-latest
-        steps:
-          - name: Connect Tailscale
-            uses: tailscale/github-action@v2
-            with:
-              oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-              oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-              tags: tag:ci
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Connect Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
 
-          - name: Deploy to AWS
-            run: |
-              ssh -o StrictHostKeyChecking=no codesirius "
-              cd /home/parthokr/segfault
-              git pull
-              docker compose up -d
-              "
+      - name: Deploy to AWS
+        run: |
+          ssh -o StrictHostKeyChecking=no codesirius "
+          cd /home/parthokr/segfault
+          git pull
+          docker compose up -d
+          "

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ DJANGO_SECRET_KEY=<your-secret-key>
 BACKEND_URL=<nextjs-backend-url>
 # Optional but requires manual configuration in settings.py
 TAILSCALE_VPN_IP=<your-tailscale-ip> # only if you are using Tailscale
-AZURE_VM_IP=<your-azure-vm-ip> # only if you are using Azure VM
-
+TAILSCALE_MAGICDNS=<your-tailscale-magicdns> # only if you are using Tailscale
 ```
 
 ## Development Guidelines

--- a/backend/codesirius/codesirius/settings.py
+++ b/backend/codesirius/codesirius/settings.py
@@ -39,7 +39,7 @@ ALLOWED_HOSTS = [
     "localhost",  # localhost for development
     "backend",  # Docker container name (for internal communication)
     environ.get("TAILSCALE_VPN_IP"),  # Tailscale VPN IP for development
-    environ.get("AZURE_VM_IP"),  # Azure VM public IP
+    environ.get("TAILSCALE_MAGICDNS"),  # Tailscale MagicDNS for development
 ]
 
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,7 +6,7 @@ http {
         server_name localhost;
 
         location / {
-            proxy_pass http://frontend:3000;  # Redirect to frontend service on port 3000
+            proxy_pass http://frontend-prod:3000;  # Redirect to frontend service on port 3000
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
This pull request includes several key updates:

*   **feat(deploy):** Implements a deploy workflow using Tailscale to connect to and deploy to an EC2 instance. This is done through a GitHub Action.
*   **fix(proxy\_pass):**  Corrects the `proxy_pass` configuration in Nginx to point to the production frontend server.
*   **fix(env):**  Removes the public IP from the environment variables and adds the private IP for improved security.
*   **fix(hosts):**  Adds the private IP to the `ALLOWED_HOSTS` in Django settings.
*   **style(format):**  Formats the YAML file for better readability.
*   **fix(path):** Loads the project path from GitHub Secrets for enhanced security and flexibility.


**Changes:**

*   **`.github/workflows/deploy.yml`:**  Added the deploy workflow file, configuring Tailscale connection and deployment to the EC2 instance via SSH.
*   **`README.md`:** Updated the `.env` example section, removing `AZURE_VM_IP` and `TAILSCALE_VPN_IP` as they are no longer needed in this specific configuration.
*   **`backend/codesirius/codesirius/settings.py`:** Modified the `ALLOWED_HOSTS` setting, removing `AZURE_VM_IP` and adding `TAILSCALE_MAGICDNS`.
*   **`nginx/nginx.conf`:** Modified `proxy_pass` to `proxy_pass http://frontend-prod:3000;`