### PR TITLE
fix(preset): load preset files after pull

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
           ssh -o StrictHostKeyChecking=no ${{ secrets.EC2_USER }}@codesirius "
           cd ${{ secrets.PROJECT_PATH }}
           git pull
+          cp /home/${{ secrets.EC2_USER }}/preset/.env .env
+          cp /home/${{ secrets.EC2_USER }}/preset/constants.ts frontend/src/lib/constants.ts
           docker compose down
           docker compose --profile production up -d
           "


### PR DESCRIPTION
This PR addresses an issue where preset files were being loaded *before* the `git pull` command.